### PR TITLE
add "install from release" test

### DIFF
--- a/tests/test.bats
+++ b/tests/test.bats
@@ -39,11 +39,11 @@ teardown() {
   locale_checks
 }
 
-# @test "install from release" {
-#   set -eu -o pipefail
-#   cd ${TESTDIR} || ( printf "unable to cd to ${TESTDIR}\n" && exit 1 )
-#   echo "# ddev get tyler36/ddev-locale with project ${PROJNAME} in ${TESTDIR} ($(pwd))" >&3
-#   ddev get tyler36/ddev-locale
-#   ddev restart >/dev/null
-#   locale_checks
-# }
+@test "install from release" {
+  set -eu -o pipefail
+  cd ${TESTDIR} || ( printf "unable to cd to ${TESTDIR}\n" && exit 1 )
+  echo "# ddev get tyler36/ddev-locale with project ${PROJNAME} in ${TESTDIR} ($(pwd))" >&3
+  ddev get tyler36/ddev-locale
+  ddev restart >/dev/null
+  locale_checks
+}


### PR DESCRIPTION
Now that we have `v0.1`, this PR adds a test to confirm we can install from the release.