### PR TITLE
Mark config as ddev-generated to allow removal.

### DIFF
--- a/config.locale.yaml
+++ b/config.locale.yaml
@@ -1,4 +1,4 @@
-## ddev-generated
+## #ddev-generated
 
 ## For a list of valid timezones:
 ## https://en.wikipedia.org/wiki/List_of_tz_database_time_zones


### PR DESCRIPTION
`config.locale.yaml` is missing the hash before `ddev-generated`. 

This PR adds it to allow the addon to be removed properly.